### PR TITLE
Correct placement of "predict" method in HW4

### DIFF
--- a/hw/forecasting_regression_supervised.ipynb
+++ b/hw/forecasting_regression_supervised.ipynb
@@ -289,7 +289,6 @@
     "\n",
     "    def predict(self, X):\n",
     "        raise NotImplementedError(\"Subclasses must implement this method\")\n",
-    "        #return X @ self.weights + self.bias\n",
     "\n",
     "    def score(self, X, y):\n",
     "        \"\"\"\n",
@@ -361,7 +360,12 @@
     "        #\n",
     "        #\n",
     "        ############################################################\n",
-    "        raise NotImplementedError\n"
+    "        raise NotImplementedError\n",
+    "\n",
+    "    def predict(self, X):\n",
+    "        return X @ self.weights + self.bias\n",
+    "\n",
+    "\n"
    ]
   },
   {


### PR DESCRIPTION
LinearRegressor class now has the predict method, previously commented out and placed incorrectly in the BaseRegressor class.