### PR TITLE
Participation Points: Fixed Spelling Mistake in hw/pde_turing.ipynb

### DIFF
--- a/hw/pde_turing.ipynb
+++ b/hw/pde_turing.ipynb
@@ -87,7 +87,7 @@
     "\n",
     "### To Do\n",
     "\n",
-    "1. Implement the Allen-Cahn equation using the method of lines. I recommend implementing just the diffusion portion first, and checking that it works, before adding on the reaction term. I've included an outline of my solution below. Once you've reduced the problem to a system of coupled ODEs, you will need to make generous use of `np.reshape`. For numerical integration, we will use the ODE solver `scipy.integrate.solve_ivp`. Review the API and docs for that function to make sure your diffential equation is set up properly. \n",
+    "1. Implement the Allen-Cahn equation using the method of lines. I recommend implementing just the diffusion portion first, and checking that it works, before adding on the reaction term. I've included an outline of my solution below. Once you've reduced the problem to a system of coupled ODEs, you will need to make generous use of `np.reshape`. For numerical integration, we will use the ODE solver `scipy.integrate.solve_ivp`. Review the API and docs for that function to make sure your differential equation is set up properly. \n",
     "2. Describe how varying $D$ and $\\kappa$ change the properties of your solution. Is this consistent with your intuition for special cases in which this equation is solvable?\n",
     "3. Try changing the mesh size, integration timestep, or integration duration. Under what conditions does the solver fail? What do failures look like for this solution method?\n",
     "4.  If you are familiar with Photoshop, you have probably used a tool called a [\"Gaussian blur,\"](https://www.youtube.com/watch?v=ri8RVzhHYoA) which blurs image details in a manner reminiscent of camera blur. This method is occasionally used in the analysis of experimental microscopy images, or even one-dimensional time series, in order to remove high-frequency information. The results of a Gaussian blur of fixed radius look very reminiscent of applying the raw diffusion equation ($\\kappa=0$) to our initial conditions for a fixed duration. Based on what you know about analytical results for the heat equation, can you guess why this might be the case? What kind of photo-editing operation does the reaction term in our system mimic?\n",
@@ -905,7 +905,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.4 ('shrec')",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -919,7 +919,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.8.8"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
## Changes Made
__What:__ Fixed a spelling mistake 

__Where:__ In the `pde_turing.ipynb` homeworkin the section __Phase separation, initial value problems, and the Method of Lines__ > __To Do__

The mistake is "diffential equation" -> "differential equation"

## Reasoning
This is a submission for the participation grade for the course. Hope this isn't too late.