### PR TITLE
Pull Request

### DIFF
--- a/hw/solutions/allencahn_spectral.py
+++ b/hw/solutions/allencahn_spectral.py
@@ -47,6 +47,7 @@ class AllenCahn:
         For technical reasons, this function needs to take a one-dimensional vector, 
         and so we have to reshape the vector back into the mesh
         """
+        #I think it would be nice to have the technical reasons for why the functon can only take a one-dimensional vector.
         return self.kappa * self._reaction(y) - self.d * self.ksq  * y
 
 


### PR DESCRIPTION
Request for the reasoning for why the RHS method in the allencahn_spectral can only take a one-dimensional vector.