### PR TITLE
doc-string typo fix in monte carlo lecture

### DIFF
--- a/talks/monte_carlo_metropolis.ipynb
+++ b/talks/monte_carlo_metropolis.ipynb
@@ -135,7 +135,7 @@
     "\n",
     "    def perturb(self, X):\n",
     "        \"\"\"\n",
-    "        Randomly the state of the system.\n",
+    "        Randomly perturb the state of the system.\n",
     "        \n",
     "        Args:\n",
     "            X (ndarray): The current state of the system\n",


### PR DESCRIPTION
Just fixed a doc-string in the Monte Carlo jupyter notebook. Sorry for the late post. 